### PR TITLE
Design Pattern

### DIFF
--- a/backend/src/api_device/views.py
+++ b/backend/src/api_device/views.py
@@ -26,6 +26,25 @@ YOUTUBE_LIVE_LINKS = [
 
 # General --------------------------------------------------------------------------
 
+'''
+Decorator
+O Decorator é um padrão de projeto estrutural 
+que permite que você acople novos comportamentos para objetos 
+ao colocá-los dentro de invólucros de objetos que contém os comportamentos.
+
+Onde foi usado:
+
+@csrf_exempt: Desativa a verificação do token CSRF (Cross-Site Request Forgery) para a view onde é aplicado
+Normalmente, o Django valida esse token em formulários para proteger contra ataques CSRF,
+mas esse decorator pode ser usado para pular essa verificação em casos específicos, como em APIs que não precisam de CSRF
+
+@require_POST: Restringe o acesso a uma view para apenas requisições do tipo POST
+Se a view for acessada por qualquer outro método HTTP (como GET),
+Django retorna um erro "405 Method Not Allowed"
+Isso é útil quando você deseja garantir que a view só seja chamada por uma requisição POST, 
+ao enviar formulários ou dados via API
+'''
+
 @csrf_exempt
 @require_POST
 def status_in_period(request):

--- a/backend/src/myapp/views.py
+++ b/backend/src/myapp/views.py
@@ -56,6 +56,19 @@ Password Requirements:
 
 # Device ->
 
+'''
+Decorator
+O Decorator é um padrão de projeto estrutural 
+que permite que você acople novos comportamentos para objetos 
+ao colocá-los dentro de invólucros de objetos que contém os comportamentos.
+
+Onde foi usado:
+
+@login_required: em Django é usado para restringir o acesso a uma view apenas para usuários autenticados.
+login_url='login': Especifica a URL para a qual o usuário será redirecionado caso não esteja autenticado.
+Neste caso, ele será redirecionado para a página de login (/login/)
+'''
+
 @login_required(login_url='login')
 def device_live(request, property_id: int, device_id: int, link: str):
     property: Property = get_object_or_404(Property, id= property_id)


### PR DESCRIPTION
# Decorator

- O Decorator é um padrão de projeto estrutural que permite que você acople novos comportamentos para objetos ao colocá-los dentro de invólucros de objetos que contém os comportamentos. #40 

Onde foi usado:

- views (back/api)
- @csrf_exempt

    - Desativa a verificação do token CSRF (Cross-Site Request Forgery) para a view onde é aplicado. Normalmente, o Django valida esse token em formulários para proteger contra ataques CSRF, esse decorator pode ser usado para pular essa verificação em casos específicos, como em APIs que não precisam de CSRF

- @require_POST

    - Restringe o acesso a uma view para apenas requisições do tipo POST. Se a view for acessada por qualquer outro método HTTP (como GET), Django retorna um erro "405 Method Not Allowed" Isso é útil quando você deseja garantir que a view só seja chamada por uma requisição POST, ao enviar formulários ou dados via API

- @login_required

    - Em Django é usado para restringir o acesso a uma view apenas para usuários autenticados
    - login_url='login': Especifica a URL para a qual o usuário será redirecionado caso não esteja autenticado. Neste caso, ele será redirecionado para a página de login (/login/)